### PR TITLE
Use TrySetResult instead  of SetResult to prevent possible exception

### DIFF
--- a/EasyClientBase.cs
+++ b/EasyClientBase.cs
@@ -272,8 +272,7 @@ namespace SuperSocket.ClientEngine
 
             if (Interlocked.CompareExchange(ref m_ConnectTaskSource, null, connectTaskSource) == connectTaskSource)
             {
-                connectTaskSource.SetResult(result);
-                return true;
+                return connectTaskSource.TrySetResult(result);
             }
 
             return false;
@@ -319,7 +318,7 @@ namespace SuperSocket.ClientEngine
             {
                 if(Interlocked.CompareExchange(ref m_CloseTaskSource, null, closeTaskSrc) == closeTaskSrc)
                 {
-                    closeTaskSrc.SetResult(true);
+                    closeTaskSrc.TrySetResult(true);
                 }
             }
 


### PR DESCRIPTION
Use TrySetResult instead  of SetResult to prevent possible exception.
--
今天在测试断网后程序能否恢复网络时，EasyClient 出现如下异常。EasyClient版本为0.8.0.14。
Unhandled Exception: System.InvalidOperationException: 在已经完成任务后，尝试将任务转换为最终状态。
   在 System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   在 SuperSocket.ClientEngine.EasyClientBase.FinishConnectTask(Boolean result)
   在 SuperSocket.ClientEngine.EasyClientBase.OnSessionError(Object sender, ErrorEventArgs e)
   在 SuperSocket.ClientEngine.AsyncTcpSession.ProcessReceive(SocketAsyncEventArgs e)
   在 System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e)
   在 System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   在 System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncFailure(SocketError socketError, Int32 bytesTransferred, SocketFlags flags)
   在 System.Net.Sockets.SocketAsyncEventArgs.CompletionPortCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   在 System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)